### PR TITLE
Fix welcome page dashboard link logic

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -33,6 +33,7 @@ class HandleInertiaRequests extends Middleware
             ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
+                'is_admin' => $request->user()?->hasRole('admin') ?? false,
             ],
         ];
     }

--- a/resources/js/Pages/Welcome.vue
+++ b/resources/js/Pages/Welcome.vue
@@ -45,7 +45,7 @@ defineProps({
                 <div v-if="canLogin" class="flex items-center gap-2">
                     <template v-if="$page.props.auth?.user">
                         <Link
-                            :href="$page.props.auth.user.roles?.includes('admin') ? route('admin.dashboard') : route('employee.dashboard')"
+                            :href="$page.props.auth.is_admin ? route('admin.dashboard') : route('employee.dashboard')"
                             class="rounded-xl border border-transparent bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-white">
                         Dashboard
                         </Link>
@@ -84,7 +84,7 @@ defineProps({
 
                     <div class="mt-6 flex flex-wrap gap-3">
                         <Link v-if="$page.props.auth?.user"
-                            :href="$page.props.auth.user.roles?.includes('admin') ? route('admin.employee.index') : route('employee.dashboard')"
+                            :href="$page.props.auth.is_admin ? route('admin.employee.index') : route('employee.dashboard')"
                             class="inline-flex items-center gap-2 rounded-xl bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white shadow hover:bg-indigo-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">
                         <svg class="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" />


### PR DESCRIPTION
Add `is_admin` prop to Inertia shared data and update `Welcome.vue` to correctly route authenticated users to their dashboards.

---
<a href="https://cursor.com/background-agent?bcId=bc-e358a9dd-8961-49a0-9f7b-184d1a35263d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e358a9dd-8961-49a0-9f7b-184d1a35263d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

