### PR TITLE
Fix change password form display issue

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -22,7 +22,7 @@ const showingNavigationDropdown = ref(false);
                         <div class="flex">
                             <!-- Logo -->
                             <div class="flex shrink-0 items-center">
-                                <Link :href="route('/admin/dashboard')">
+                                <Link :href="route($page.props.auth.is_admin ? 'admin.dashboard' : 'employee.dashboard')">
                                     <ApplicationLogo
                                         class="block h-9 w-auto fill-current text-gray-800"
                                     />
@@ -34,8 +34,8 @@ const showingNavigationDropdown = ref(false);
                                 class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex"
                             >
                                 <NavLink
-                                    :href="route('admin/dashboard')"
-                                    :active="route().current('admin/dashboard')"
+                                    :href="route($page.props.auth.is_admin ? 'admin.dashboard' : 'employee.dashboard')"
+                                    :active="$page.props.auth.is_admin ? route().current('admin.dashboard') : route().current('employee.dashboard')"
                                 >
                                     Dashboard
                                 </NavLink>
@@ -141,8 +141,8 @@ const showingNavigationDropdown = ref(false);
                 >
                     <div class="space-y-1 pb-3 pt-2">
                         <ResponsiveNavLink
-                            :href="route('dashboard')"
-                            :active="route().current('dashboard')"
+                            :href="route($page.props.auth.is_admin ? 'admin.dashboard' : 'employee.dashboard')"
+                            :active="$page.props.auth.is_admin ? route().current('admin.dashboard') : route().current('employee.dashboard')"
                         >
                             Dashboard
                         </ResponsiveNavLink>


### PR DESCRIPTION
Update dashboard links in `AuthenticatedLayout.vue` to use role-based named routes, fixing the issue where the change password form was not showing for admin and employees.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ce92ad1-8822-43eb-a50b-5f2ea199b4b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ce92ad1-8822-43eb-a50b-5f2ea199b4b4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

